### PR TITLE
Pomodoro program updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `short-break` program changed from `10 minutes` to `5 minutes`
+- `long-break` program changed from `30 minutes` to `15 minutes`
+- `pomodoro` program updated
 ## [1.2] - 2024-02-05
 ### Added
 - `feature_request.yml` template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- `short-break` program changed from `10 minutes` to `5 minutes`
-- `long-break` program changed from `30 minutes` to `15 minutes`
+- `short-break` program duration changed from `10 minutes` to `5 minutes`
+- `long-break` program duration changed from `30 minutes` to `15 minutes`
 - `pomodoro` program updated
 ## [1.2] - 2024-02-05
 ### Added

--- a/PROGRAMS.md
+++ b/PROGRAMS.md
@@ -114,7 +114,7 @@
 	<tr align="center">
 		<td>Pomodoro</td>
 		<td><code>pomodoro</code></td>
-		<td>02:40:00</td>
+		<td>02:10:00</td>
 		<td>>=1.1</td>
 	</tr>
 	<tr align="center">

--- a/PROGRAMS.md
+++ b/PROGRAMS.md
@@ -96,13 +96,13 @@
 	<tr align="center">
 		<td>Short break</td>
 		<td><code>short-break</code></td>
-		<td>00:10:00</td>
+		<td>00:05:00</td>
 		<td>>=0.9</td>
 	</tr>
 	<tr align="center">
 		<td>Long break</td>
 		<td><code>long-break</code></td>
-		<td>00:30:00</td>
+		<td>00:15:00</td>
 		<td>>=0.9</td>
 	</tr>
 	<tr align="center">

--- a/mytimer/params.py
+++ b/mytimer/params.py
@@ -177,15 +177,15 @@ PROGRAMS_MAP = {
     },
     "short-break": {
         "hour": 0,
-        "minute": 10,
+        "minute": 5,
         "second": 0,
-        "message": "Short break (10 mins)",
+        "message": "Short break (5 mins)",
     },
     "long-break": {
         "hour": 0,
-        "minute": 30,
+        "minute": 15,
         "second": 0,
-        "message": "Long break (30 mins)",
+        "message": "Long break (15 mins)",
     },
     "noodle": {
         "hour": 0,


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
- `short-break` program duration changed from `10 minutes` to `5 minutes`
- `long-break` program duration changed from `30 minutes` to `15 minutes`
- `pomodoro` program updated
#### Any other comments?
Most websites offer a Pomodoro timer that follows the **25-5-15** sequence. We plan to add an "Animedoro" #83 timer in the near future, so it would be better to update the Pomodoro program to the standard version.

