### PR TITLE
`--set-on` Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - 2 new programs
 	1. `puer-tea`
 	2. `purple-tea`
+- `--set-on` argument
 ## [1.5] - 2024-08-12
 ### Added
 - 2 new programs

--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ In this mode, the timer will continue running after it times out
 mytimer --minute=5 --keep-on
 ```
 
+### Set on
+
+In this mode, the timer sets on the given time. For example, here you set a timer for `15:05`.
+
+```console
+mytimer --hour=15 --minute=5 --set-on
+```
 
 ### Program
 

--- a/mytimer/__main__.py
+++ b/mytimer/__main__.py
@@ -50,6 +50,7 @@ def main():
     parser.add_argument('--countup', help='countup timer', nargs="?", const=1)
     parser.add_argument('--alarm', help='alarm', nargs="?", const=1)
     parser.add_argument('--keep-on', help='keep-on', nargs="?", const=1)
+    parser.add_argument('--set-on', help='set-on', nargs="?", const=1)
     parser.add_argument('--faces-list', help='faces list', nargs="?", const=1)
     parser.add_argument('--version', help='version', nargs="?", const=1)
     parser.add_argument(

--- a/mytimer/functions.py
+++ b/mytimer/functions.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import time
+import datetime
 from nava import play
 from mytimer.params import INPUT_ERROR_MESSAGE, SOUND_ERROR_MESSAGE
 from mytimer.params import INPUT_EXAMPLE, TIME_ELEMENTS, MESSAGE_TEMPLATE
@@ -11,6 +12,7 @@ from mytimer.params import MY_TIMER_VERSION, PROGRAMS_LIST_TEMPLATE
 from mytimer.params import FACES_LIST_EXAMPLE_MESSAGE, TIME_PRINT_TEMPLATE
 from mytimer.params import DEFAULT_PARAMS, PROGRAMS_DEFAULTS, BREAKS_DEFAULTS
 from mytimer.params import NEXT_PROGRAM_MESSAGE, END_ROUND_MESSAGE
+from mytimer.params import KEEP_ON_MESSAGE, SET_ON_MESSAGE
 from art import tprint
 
 
@@ -470,6 +472,33 @@ def keep_on_timer(params):
     countup_timer(**params)
 
 
+def set_on_timer(params):
+    """
+    Set-on timer.
+
+    :param params: timer params
+    :type params: dict
+    :return: None
+    """
+    if params["message"] == "":
+        params["message"] = SET_ON_MESSAGE.format(params["hour"], params["minute"], params["second"])
+    time_now = datetime.datetime.now()
+    time_then = datetime.datetime(
+        time_now.year,
+        time_now.month,
+        time_now.day,
+        params["hour"],
+        params["minute"],
+        params["second"])
+    if time_then < time_now:
+        time_then += datetime.timedelta(days=1)
+    time_diff = time_then - time_now
+    params["hour"] = time_diff.seconds // 3600
+    params["minute"] = time_diff.seconds % 3600 // 60
+    params["second"] = time_diff.seconds % 60
+    return params, countdown_timer
+
+
 def run_timer(args):
     """
     Run timer.
@@ -482,6 +511,8 @@ def run_timer(args):
     timer_func = countup_timer
     if args.countdown:
         timer_func = countdown_timer
+    if args.set_on:
+        params, timer_func = set_on_timer(params)
     if args.version:
         print(MY_TIMER_VERSION)
     elif args.faces_list:

--- a/mytimer/functions.py
+++ b/mytimer/functions.py
@@ -472,13 +472,13 @@ def keep_on_timer(params):
     countup_timer(**params)
 
 
-def set_on_timer(params):
+def update_set_on_params(params):
     """
-    Set-on timer.
+    Update set-on mode params.
 
     :param params: timer params
     :type params: dict
-    :return: None
+    :return: timer params as dict
     """
     if params["message"] == "":
         params["message"] = SET_ON_MESSAGE.format(params["hour"], params["minute"], params["second"])
@@ -496,7 +496,7 @@ def set_on_timer(params):
     params["hour"] = time_diff.seconds // 3600
     params["minute"] = time_diff.seconds % 3600 // 60
     params["second"] = time_diff.seconds % 60
-    return params, countdown_timer
+    return params
 
 
 def run_timer(args):
@@ -509,10 +509,13 @@ def run_timer(args):
     """
     params = load_params(args)
     timer_func = countup_timer
+    if args.set_on:
+        timer_func = countdown_timer
+        params = update_set_on_params(params)
     if args.countdown:
         timer_func = countdown_timer
-    if args.set_on:
-        params, timer_func = set_on_timer(params)
+    if args.countup:
+        timer_func = countup_timer
     if args.version:
         print(MY_TIMER_VERSION)
     elif args.faces_list:

--- a/mytimer/functions.py
+++ b/mytimer/functions.py
@@ -462,7 +462,7 @@ def keep_on_timer(params):
     :return: None
     """
     params["hour"] = 10000000
-    params["message"] += " **Timeout!"
+    params["message"] += KEEP_ON_MESSAGE
     if params["sign"] in ["+", ""]:
         params["sign"] = "-"
     else:

--- a/mytimer/params.py
+++ b/mytimer/params.py
@@ -14,6 +14,8 @@ FACES_LIST_EXAMPLE_MESSAGE = "12 : 34 : 56"
 INPUT_EXAMPLE = "Example: mytimer --hour=1 --minute=1 --second=1"
 TIME_ELEMENTS = ["minute", "second", "hour"]
 MESSAGE_TEMPLATE = "Message: {0}"
+KEEP_ON_MESSAGE = " **Timeout!"
+SET_ON_MESSAGE = "Timer set for {0:02d}:{1:02d}:{2:02d}"
 
 SIGNS_LIST = ["", "+", "-"]
 


### PR DESCRIPTION
#### Reference Issues/PRs
#97 

#### What does this implement/fix? Explain your changes.
`--set-on` parameter added to the program. Now users can set a timer for a specific time (based on their local time).
When the setting time passed, I assumed that it was for the next day. In other words, it sets the timer to the nearest matching time in the future.

#### Any other comments?
Also, I moved the `keep_on` message to `params.py`.
